### PR TITLE
Fix codespell on .github/labels.yml

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -4,7 +4,7 @@
   description: "A breaking change for existing users."
 - name: "bugfix"
   color: ee0701
-  description: "Inconsistencies or issues which will cause a problem for users or implementors."
+  description: "Inconsistencies or issues which will cause a problem for users or implementers."
 - name: "documentation"
   color: 0052cc
   description: "Solely about the documentation of the project."


### PR DESCRIPTION
This is inconsequential, but I noticed that `poetry run pre-commit run --all-files` would fail as it flags a typo in `labels.yml`. Fix the typo.