### PR TITLE
Add energy data to thermostat

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ These fields are only available on WD5-series thermostats; for others, they may 
 | `boost_end_time` | datetime | If the regulation mode is set to boost mode, it will end at this time. |
 | `frost_protection_temperature` | integer | If the regulation mode is set to frost protection mode, the thermostat will target this temperature. |
 | `schedule` | Schedule | The schedule the thermostat currently uses. (This *could* be supported by WG4-series thermostats, it simply isn't implemented.) |
+| `energy` | list | The energy usage in kWh for the current day and the six previous days. (Note that the integrated tariff calculation needs to be disabled.) |
 
 These fields are only available on WG4-series thermostats; for others, they may be `None`:
 
@@ -110,6 +111,7 @@ Keep in mind that certain thermostats only support a subset of these modes; be s
 | `login` | `None` | Create a new session at the OJ Microline API. |
 | `get_thermostats` | `None` | Get all thermostats from the OJ Microline API. |
 | `set_regulation_mode` | `resource: Thermostat`, `regulation_mode: int`, `temperature: int \| None = None`, `duration: int = COMFORT_DURATION` | Set the regulation mode based on the input.<br> - `resource`: An instance of a Thermostat model returned by `get_thermostats()`<br> - `regulation_mode`: An integer representing the regulation mode, see "Regulation modes"<br> - `temperature`: An integer representing the temperature, eg: 2500. Only useful when setting the regulation mode to manual or comfort.<br> - `duration`: The duration in minutes to set the temperature for; only applies to comfort mode. |
+| `get_current_energy` | None | Return the current energy usage in kWh. This is the first value in the `energy` property list. |
 
 ## Usage
 

--- a/config_example.py
+++ b/config_example.py
@@ -1,0 +1,7 @@
+# Rename this file to config.py and fill in the necessary information
+config = dict(
+    customer_id=99,
+    api_key="<API_KEY>",
+    username="username",
+    password="password"
+)

--- a/config_example.py
+++ b/config_example.py
@@ -1,7 +1,7 @@
 # Rename this file to config.py and fill in the necessary information
 config = dict(
-    customer_id=99,
-    api_key="<API_KEY>",
-    username="username",
-    password="password"
+    customer_id=99,  # Can be found in the app under thermostat information.
+    api_key="<api_key>",
+    username="<username>",
+    password="<password>",
 )

--- a/ojmicroline_thermostat/models/thermostat.py
+++ b/ojmicroline_thermostat/models/thermostat.py
@@ -64,8 +64,7 @@ class Thermostat:
     vacation_temperature: int | None = None
     frost_protection_temperature: int | None = None
     boost_temperature: int | None = None
-    energy_current: float | None = None
-    energy_yesterday: float | None = None
+    energy: list[float] | None = None
 
     # WG4-only fields:
     temperature: int | None = None
@@ -234,6 +233,19 @@ class Thermostat:
             )
 
         return 0
+
+    def get_current_energy(self) -> float:
+        """Return the current energy usage for the thermostat.
+
+        Returns
+        -------
+            The current energy usage.
+
+        """
+        if self.energy is None:
+            return 0
+
+        return self.energy[0]
 
 
 def parse_wd5_date(value: str, offset: int) -> datetime:

--- a/ojmicroline_thermostat/models/thermostat.py
+++ b/ojmicroline_thermostat/models/thermostat.py
@@ -239,13 +239,13 @@ class Thermostat:
 
         Returns
         -------
-            The current energy usage.
+            The current energy usage in kWh.
 
         """
-        if self.energy is None:
-            return 0
-
-        return self.energy[0]
+        if self.energy is not None:
+            return self.energy[0]
+        
+        return 0.0
 
 
 def parse_wd5_date(value: str, offset: int) -> datetime:

--- a/ojmicroline_thermostat/models/thermostat.py
+++ b/ojmicroline_thermostat/models/thermostat.py
@@ -64,6 +64,8 @@ class Thermostat:
     vacation_temperature: int | None = None
     frost_protection_temperature: int | None = None
     boost_temperature: int | None = None
+    energy_current: float | None = None
+    energy_yesterday: float | None = None
 
     # WG4-only fields:
     temperature: int | None = None

--- a/ojmicroline_thermostat/ojmicroline.py
+++ b/ojmicroline_thermostat/ojmicroline.py
@@ -278,11 +278,10 @@ class OJMicroline:
 
         return thermostats
 
-    async def get_energy_usage(self, resource: Thermostat) -> dict[str, Any]:
+    async def get_energy_usage(self, resource: Thermostat) -> list[float]:
         """Get the energy usage.
 
-        Get the energy usage for the provided thermostat. The input
-        can be a Thermostat model or a string containing the serial number.
+        Get the energy usage for the provided thermostat. 
 
         Args:
         ----
@@ -290,7 +289,7 @@ class OJMicroline:
 
         Returns:
         -------
-            A dictionary with the energy usage.
+            A list with the energy usage for the current day and the six previous days.
 
         Raises:
         ------

--- a/ojmicroline_thermostat/ojmicroline.py
+++ b/ojmicroline_thermostat/ojmicroline.py
@@ -274,9 +274,7 @@ class OJMicroline:
 
         # add energy data to each thermostat
         for thermostat in thermostats:
-            energy_usage = await self.get_energy_usage(thermostat)
-            thermostat.energy_current = energy_usage['energy_current']
-            thermostat.energy_yesterday = energy_usage['energy_yesterday']
+            thermostat.energy = await self.get_energy_usage(thermostat)
 
         return thermostats
 

--- a/ojmicroline_thermostat/ojmicroline.py
+++ b/ojmicroline_thermostat/ojmicroline.py
@@ -69,14 +69,14 @@ class OJMicrolineAPI(Protocol):
 
         """
 
-    def parse_energy_usage_response(self, data: Any) -> dict[str, Any]:
+    def parse_energy_usage_response(self, data: Any) -> list[float]:
         """Parse an HTTP response containing energy usage data.
 
         Args:
         ----
             data: The JSON data contained in the response.
 
-        Returns: A dictionary with the energy usage.
+        Returns: A list with the energy usage values.
 
         """
 

--- a/ojmicroline_thermostat/ojmicroline.py
+++ b/ojmicroline_thermostat/ojmicroline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 import json
 import socket
 from dataclasses import dataclass
@@ -53,6 +54,29 @@ class OJMicrolineAPI(Protocol):
         Args:
         ----
             data: The JSON data contained in the response.
+
+        """
+
+    get_energy_usage_path: str
+    """HTTP path used to fetch energy usage data."""
+
+    def get_energy_usage_params(self, thermostat: Thermostat) -> dict[str, Any]:
+        """Compute additional query string params for fetching energy usage.
+
+        Args:
+        ----
+            thermostat: The Thermostat model.
+
+        """
+
+    def parse_energy_usage_response(self, data: Any) -> dict[str, Any]:
+        """Parse an HTTP response containing energy usage data.
+
+        Args:
+        ----
+            data: The JSON data contained in the response.
+
+        Returns: A dictionary with the energy usage.
 
         """
 
@@ -246,7 +270,57 @@ class OJMicroline:
                 **self.__api.get_thermostats_params(),
             },
         )
-        return self.__api.parse_thermostats_response(data)
+        thermostats = self.__api.parse_thermostats_response(data)
+
+        # add energy data to each thermostat
+        for thermostat in thermostats:
+            energy_usage = await self.get_energy_usage(thermostat)
+            thermostat.energy_current = energy_usage['energy_current']
+            thermostat.energy_yesterday = energy_usage['energy_yesterday']
+
+        return thermostats
+
+    async def get_energy_usage(self, resource: Thermostat) -> dict[str, Any]:
+        """Get the energy usage.
+
+        Get the energy usage for the provided thermostat. The input
+        can be a Thermostat model or a string containing the serial number.
+
+        Args:
+        ----
+            resource: The Thermostat model.
+
+        Returns:
+        -------
+            A dictionary with the energy usage.
+
+        Raises:
+        ------
+            OJMicrolineError: An error occurred while fetching the energy usage.
+
+        """
+        if self.__session_id is None:
+            await self.login()
+
+        date_tomorrow = (datetime.now() + timedelta(days=1)
+                         ).strftime("%Y-%m-%d")
+
+        data = await self._request(
+            self.__api.get_energy_usage_path,
+            method=hdrs.METH_POST,
+            params={
+                "sessionid": self.__session_id,
+            },
+            body={
+                **self.__api.get_thermostats_params(),
+                "ThermostatID": resource.serial_number,
+                "ViewType": 2,
+                "DateTime": date_tomorrow,
+                "History": 0
+            }
+        )
+
+        return self.__api.parse_energy_usage_response(data)
 
     async def set_regulation_mode(
         self,

--- a/ojmicroline_thermostat/wd5.py
+++ b/ojmicroline_thermostat/wd5.py
@@ -87,10 +87,8 @@ class WD5API(OJMicrolineAPI):
             msg = "Unable to get energy usage via API."
             raise OJMicrolineResultsError(msg, {"data": data})
 
-        energy = dict(
-            energy_current=data["EnergyUsage"][0]["Usage"][0]['EnergyKWattHour'],
-            energy_yesterday=data["EnergyUsage"][0]["Usage"][1]['EnergyKWattHour'],
-        )
+        energy = [d['EnergyKWattHour']
+                  for d in data["EnergyUsage"][0]["Usage"]]
         return energy
 
     update_regulation_mode_path: str = "api/Group/UpdateGroup"

--- a/ojmicroline_thermostat/wd5.py
+++ b/ojmicroline_thermostat/wd5.py
@@ -80,6 +80,19 @@ class WD5API(OJMicrolineAPI):
                     results.append(Thermostat.from_wd5_json(item))
         return results
 
+    get_energy_usage_path: str = "api/EnergyUsage/GetEnergyUsage"
+
+    def parse_energy_usage_response(self, data: dict) -> list[dict]:  # noqa: D102
+        if data["ErrorCode"] == 1:
+            msg = "Unable to get energy usage via API."
+            raise OJMicrolineResultsError(msg, {"data": data})
+
+        energy = dict(
+            energy_current=data["EnergyUsage"][0]["Usage"][0]['EnergyKWattHour'],
+            energy_yesterday=data["EnergyUsage"][0]["Usage"][1]['EnergyKWattHour'],
+        )
+        return energy
+
     update_regulation_mode_path: str = "api/Group/UpdateGroup"
 
     def update_regulation_mode_params(  # noqa: D102

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ojmicroline-thermostat"
-version = "3.2.0"
+version = "3.2.1"
 description = "Asynchronous Python client controlling an OJ Microline Thermostat."
 authors = ["Robbin Janssen <robbinjanssen@gmail.com>"]
 maintainers = ["Robbin Janssen <robbinjanssen@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ojmicroline-thermostat"
-version = "3.2.1"
+version = "3.3.0"
 description = "Asynchronous Python client controlling an OJ Microline Thermostat."
 authors = ["Robbin Janssen <robbinjanssen@gmail.com>"]
 maintainers = ["Robbin Janssen <robbinjanssen@gmail.com>"]

--- a/test_output.py
+++ b/test_output.py
@@ -72,8 +72,8 @@ async def main() -> None:
             print(f"   Target: {resource.get_target_temperature()}")
             print(f"   Range: {resource.min_temperature} - {resource.max_temperature}")
             print("- Energy:")
-            print(f"   Energy current: {resource.energy_current}")
-            print(f"   Energy yesterday: {resource.energy_yesterday}")
+            print(f"   Energy current: {resource.get_current_energy()}")
+            print(f"   Energy history: {resource.energy}")
             print("- Dates:")
             print(f"   Comfort End: {resource.comfort_end_time.strftime(DATETIME_FORMAT)}")
             if resource.boost_end_time is not None:

--- a/test_output.py
+++ b/test_output.py
@@ -5,6 +5,7 @@
 import asyncio
 from asyncio import sleep
 
+from config import config
 from ojmicroline_thermostat import WD5API, OJMicroline
 from ojmicroline_thermostat.const import (
     REGULATION_BOOST,
@@ -42,10 +43,10 @@ async def main() -> None:
     """Show example on using the OJ Microline client."""
     async with OJMicroline(
         api=WD5API(
-            customer_id=99,
-            api_key="<app-api-key>",
-            username="<your-username>",
-            password="<your-password>",
+            customer_id=config['customer_id'],
+            api_key=config['api_key'],
+            username=config['username'],
+            password=config['password'],
         ),
     ) as client:
         # fmt: off
@@ -70,6 +71,9 @@ async def main() -> None:
             print(f"   Current: {resource.get_current_temperature()}")
             print(f"   Target: {resource.get_target_temperature()}")
             print(f"   Range: {resource.min_temperature} - {resource.max_temperature}")
+            print("- Energy:")
+            print(f"   Energy current: {resource.energy_current}")
+            print(f"   Energy yesterday: {resource.energy_yesterday}")
             print("- Dates:")
             print(f"   Comfort End: {resource.comfort_end_time.strftime(DATETIME_FORMAT)}")
             if resource.boost_end_time is not None:


### PR DESCRIPTION
Adds method for fetching the energy data for the MWD5 thermostat.

The property `energy` has been added to the Thermostat class. This holds the list of energy values from the API (the current day, and the previous six days).

The method `get_current_energy` has been added to fetch the current day energy value (first value in the list described above). This value is cumulative increasing in unit kWh, and is planned to be used in the Home Assistant integration to provide integration with the Energy reporting.